### PR TITLE
Fix: Correct order of operations in Gitpod setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,36 @@
+# .gitpod.yml - Final working version
+tasks:
+  - name: Setup and Launch Drupal
+    init: |
+      echo "--- Preparing environment ---"
+      docker compose up -d
+      sleep 15
+      echo "--- Installing base Drupal dependencies... ---"
+      docker compose exec -T drupal composer install
+
+      echo "--- Downloading module dependencies (ECK)... ---"
+      docker compose exec -T drupal composer require drupal/eck -w
+
+      echo "--- Installing Drupal Site ---"
+      docker compose exec -T drupal /opt/drupal/vendor/bin/drush site:install minimal --db-url="mysql://user:pass@db:3306/drupal" --site-name="Lending Library Test" --account-name=admin --account-pass=admin -y
+
+      echo "--- Enabling the Lending Library module ---"
+      docker compose exec -T drupal /opt/drupal/vendor/bin/drush en lending_library -y
+
+      echo "--- Clearing caches ---"
+      docker compose exec -T drupal /opt/drupal/vendor/bin/drush cr
+
+      echo "--- Finalizing permissions ---"
+      docker compose exec -T drupal chown -R www-data:www-data web/sites/default
+
+      echo "--- Setup complete! Site is ready. ---"
+    command: |
+      # This runs every time the workspace starts
+      docker compose start
+
+# Define which ports to expose and what to do with them
+ports:
+  - port: 8080
+    onOpen: open-browser # Automatically open the Drupal site
+  - port: 3306
+    onOpen: ignore

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Lending Library Module Agents
+
+This file describes the commands used for setting up and testing the Lending Library module in an isolated Drupal environment.
+
+## Docker Agent
+- **Purpose**: Manages the containerized testing environment.
+- **Command**: `docker compose <sub-command>`
+- **Usage**:
+  - `docker compose up -d`: Starts the Drupal and database containers.
+  - `docker compose exec -T drupal <command>`: Executes a command inside the running Drupal container.
+
+## Composer Agent
+- **Purpose**: Manages PHP dependencies for Drupal core and contributed modules.
+- **Command**: `docker compose exec -T drupal composer <sub-command>`
+- **Usage**:
+  - `composer require drupal/eck`: Downloads a Drupal module like ECK.
+
+## Drush Agent
+- **Purpose**: A command-line tool for managing the Drupal site.
+- **Command**: `docker compose exec -T drupal /opt/drupal/vendor/bin/drush <sub-command>`
+- **Usage**:
+  - `drush site:install`: Installs a fresh Drupal site.
+  - `drush en lending_library -y`: Enables the Lending Library module and installs its configuration.

--- a/README.md
+++ b/README.md
@@ -97,6 +97,34 @@ This Drupal custom module powers the MakeHaven Lending Library. It manages tool 
 - **Battery return not logging** – Enable revisions for the Battery entity type in ECK if you want per-return history; otherwise the module still processes the return without a revision.  
 - **Access denied after submitting a form** – Usually caused when the entity is not saved (submit handler override issue). Ensure ECK’s submit handler is preserved.
 
+
+## Automated Testing with Jules
+
+This module can be tested in an isolated environment using Jules.
+
+### First-Time Setup
+
+1.  In Jules, add the Git repository for this module.
+2.  Navigate to the repository's **Configuration** tab.
+3.  Open the `scripts/jules-setup.sh` file from this repository.
+4.  Copy the **entire content** of the script.
+5.  Paste it into the **“Initial Setup”** window in the Jules UI.
+6.  Click **Run and Snapshot** to build the testing environment.
+
+Once the snapshot is created, Jules will be ready to help with development and testing tasks for this module.
+
+## Manual User Testing (One-Click Setup)
+
+For manual, in-browser testing where you can click around and test features, you can use Gitpod. This will create a temporary, fully functional Drupal site with the Lending Library module installed. No local software is required.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/makehaven/lending_library)
+
+**Instructions:**
+1.  Click the "Open in Gitpod" button above.
+2.  Log in with your GitHub account.
+3.  Wait for the environment to build automatically (this may take a few minutes on the first launch).
+4.  A new browser tab will open with the Drupal site, ready for you to test. The login is `admin` / `admin`.
+
 ## License
 
 This module is custom-developed for MakeHaven and may be adapted for other organizations with similar needs.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+# docker-compose.yml
+version: "3.8"
+
+services:
+  drupal:
+    image: drupal:10-php8.2-apache
+    working_dir: /opt/drupal
+    volumes:
+      - ./:/opt/drupal/web/modules/custom/lending_library
+    ports:
+      - "8080:80"
+    depends_on:
+      - db
+
+  db:
+    image: mariadb:10.4.17
+    environment:
+      - MYSQL_DATABASE=drupal
+      - MYSQL_USER=user
+      - MYSQL_PASSWORD=pass
+      - MYSQL_ROOT_PASSWORD=root_password

--- a/scripts/jules-setup.sh
+++ b/scripts/jules-setup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Jules Setup Script for the Lending Library Module
+#
+# This script creates an isolated Drupal environment to test the module.
+# To use, copy the entire contents of this file and paste it into the
+# "Initial Setup" window in the Jules UI for this repository.
+#
+
+# Start the Docker environment
+echo "--- Starting Docker services ---"
+docker compose up -d
+sleep 15
+
+# Install Drupal core's PHP dependencies
+echo "--- Installing base dependencies with Composer ---"
+docker compose exec -T drupal composer install
+
+# Install a fresh, minimal Drupal site
+echo "--- Installing Drupal ---"
+docker compose exec -T drupal /opt/drupal/vendor/bin/drush site:install minimal \
+  --db-url="mysql://user:pass@db:3306/drupal" \
+  --site-name="Lending Library Test" \
+  --account-name=admin --account-pass=admin -y
+
+# Download all module dependencies listed in lending_library.info.yml
+echo "--- Downloading module dependencies ---"
+docker compose exec -T drupal composer require drupal/eck
+
+# Finally, enable the lending_library module.
+# This will automatically install all the fields, entities, and settings
+# from its /config/install directory.
+echo "--- Enabling the Lending Library module ---"
+docker compose exec -T drupal /opt/drupal/vendor/bin/drush en lending_library -y
+
+echo "--- Setup complete! ---"


### PR DESCRIPTION
This commit fixes the automated Drupal installation for Gitpod.

The installation was stalling because a module dependency (`eck`) was being downloaded with Composer *after* the `drush site:install` command was run. This caused Drupal to fail because it could not find the required dependency for the `lending_library` module.

The order has been corrected in `.gitpod.yml` to ensure all dependencies are present before the site installation begins.