### PR TITLE
Fix and improve waitlist functionality

### DIFF
--- a/lending_library.module
+++ b/lending_library.module
@@ -606,9 +606,10 @@ function _lending_library_transaction_form_submit(array &$form, FormStateInterfa
           $waitlist_users = $library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->referencedEntities();
           $next_user = reset($waitlist_users);
           if ($next_user) {
+            // Notify the next person in line, but do not remove them from the
+            // waitlist. They will be removed when they borrow the item, or
+            // they can choose to leave the waitlist.
             _lending_library_send_email_by_key($transaction_entity, 'waitlist_notification', ['next_user' => $next_user]);
-            $library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->removeItem(0);
-            $library_item_node->save();
           }
         }
 
@@ -673,6 +674,17 @@ function lending_library_entity_insert(EntityInterface $entity) {
         : $library_item_node->get(LENDING_LIBRARY_ITEM_STATUS_FIELD)->value;
 
       if ($current === LENDING_LIBRARY_ITEM_STATUS_AVAILABLE && $transaction_borrower_uid) {
+        // If the borrower is on the waitlist, remove them.
+        if ($library_item_node->hasField(LENDING_LIBRARY_ITEM_WAITLIST_FIELD) && !$library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->isEmpty()) {
+          $waitlist_items = $library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->getValue();
+          foreach ($waitlist_items as $delta => $item) {
+            if (isset($item['target_id']) && $item['target_id'] == $transaction_borrower_uid) {
+              $library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->removeItem($delta);
+              break;
+            }
+          }
+        }
+
         // Update tool.
         $library_item_node->set(LENDING_LIBRARY_ITEM_STATUS_FIELD, LENDING_LIBRARY_ITEM_STATUS_BORROWED);
         $library_item_node->set(LENDING_LIBRARY_ITEM_BORROWER_FIELD, ['target_id' => $transaction_borrower_uid]);
@@ -1086,7 +1098,11 @@ function lending_library_entity_view(array &$build, EntityInterface $entity, \Dr
       if ($item_details['status'] === LENDING_LIBRARY_ITEM_STATUS_BORROWED && $library_item_node->hasField(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)) {
         $waitlist_users = $library_item_node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->getValue();
         $user_ids = array_column($waitlist_users, 'target_id');
-        if (!in_array($current_user->id(), $user_ids)) {
+        if (in_array($current_user->id(), $user_ids)) {
+          $url = Url::fromRoute('lending_library.waitlist_remove', ['node' => $library_item_node->id()]);
+          $links['waitlist'] = ['#type' => 'link', '#title' => t('Leave Waitlist'), '#url' => $url, '#attributes' => ['class' => ['button', 'lending-library-button']]];
+        }
+        else {
           $url = Url::fromRoute('lending_library.waitlist_add', ['node' => $library_item_node->id()]);
           $links['waitlist'] = ['#type' => 'link', '#title' => t('Get in Line'), '#url' => $url, '#attributes' => ['class' => ['button', 'lending-library-button']]];
         }

--- a/lending_library.routing.yml
+++ b/lending_library.routing.yml
@@ -65,6 +65,15 @@ lending_library.waitlist_add:
     _permission: 'get in line for library items'
     node: \d+
 
+lending_library.waitlist_remove:
+  path: '/library/item/{node}/waitlist/remove'
+  defaults:
+    _controller: '\Drupal\lending_library\Controller\WaitlistController::remove'
+    _title: 'Leave Waitlist'
+  requirements:
+    _permission: 'get in line for library items'
+    node: \d+
+
 
 lending_library.battery_return:
   path: '/library/battery/{battery}/return'

--- a/src/Controller/WaitlistController.php
+++ b/src/Controller/WaitlistController.php
@@ -30,4 +30,25 @@ class WaitlistController extends ControllerBase {
     return new RedirectResponse($node->toUrl()->toString());
   }
 
+  /**
+   * Removes the current user from the waitlist for a library item.
+   */
+  public function remove(NodeInterface $node) {
+    if ($node->bundle() === 'library_item' && $node->hasField(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)) {
+      $waitlist_users = $node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->getValue();
+      $current_user_id = $this->currentUser()->id();
+
+      foreach ($waitlist_users as $delta => $item) {
+        if ($item['target_id'] == $current_user_id) {
+          $node->get(LENDING_LIBRARY_ITEM_WAITLIST_FIELD)->removeItem($delta);
+          $node->save();
+          $this->messenger()->addStatus($this->t('You have been removed from the waitlist for %title.', ['%title' => $node->label()]));
+          break;
+        }
+      }
+    }
+
+    return new RedirectResponse($node->toUrl()->toString());
+  }
+
 }


### PR DESCRIPTION
This commit addresses several issues with the waitlist functionality in the lending_library module.

Features and Fixes:
- Adds a 'Leave Waitlist' button for users who are already on a waitlist.
- Implements logic to automatically remove a user from the waitlist when they borrow the corresponding item.
- Corrects the notification logic to no longer prematurely remove a user from the waitlist upon notifying them.
- The 'Get in Line' link is now correctly generated, which should resolve the previously reported RouteNotFoundException after a cache clear.