### PR TITLE
This commit implements a major overhaul of the overdue billing system…

### DIFF
--- a/config/install/lending_library.settings.yml
+++ b/config/install/lending_library.settings.yml
@@ -14,3 +14,5 @@ overdue_charge_days: 30
 non_return_charge_percentage: 150
 email_overdue_late_fee_subject: 'Late fee added for overdue tool'
 email_overdue_late_fee_body: "Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]"
+email_non_return_charge_subject: 'Charge for unreturned library tool'
+email_non_return_charge_body: "Hello [borrower_name],\n\nThe tool '[tool_name]' is now considered lost. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]"

--- a/lending_library.module
+++ b/lending_library.module
@@ -479,10 +479,14 @@ if (empty($terms_html)) {
 }
 
 $replacement_value = $item_details['replacement_value'] ?? 0;
+$config = \Drupal::config('lending_library.settings');
+$non_return_percentage = ($config->get('non_return_charge_percentage') ?: 150) / 100;
+$tool_replacement_charge = $replacement_value * $non_return_percentage;
+
 $replacements = [
   '[due_date]' => $due_date_display,
   '[replacement_value]' => number_format($replacement_value, 2),
-  '[replacement_value_150]' => number_format($replacement_value * 1.5, 2),
+  '[tool_replacement_charge]' => number_format($tool_replacement_charge, 2),
 ];
 
 $processed_terms = str_replace(array_keys($replacements), array_values($replacements), $terms_html);
@@ -1006,7 +1010,9 @@ function _lending_library_process_non_return_charge(EntityInterface $transaction
   }
 
   $replacement_charge = $replacement_value * ($non_return_charge_percentage / 100);
-  $battery_charge = _lending_library_calculate_unreturned_battery_value($transaction);
+
+  $battery_value = _lending_library_calculate_unreturned_battery_value($transaction);
+  $battery_charge = $battery_value * ($non_return_charge_percentage / 100);
 
   $total_due = $replacement_charge + $battery_charge;
 
@@ -1032,7 +1038,11 @@ function _lending_library_process_non_return_charge(EntityInterface $transaction
   $transaction->save();
 
   // Send email
-  _lending_library_send_email_by_key($transaction, 'overdue_30_day', ['amount_due' => $total_due]);
+  _lending_library_send_email_by_key($transaction, 'overdue_30_day', [
+    'amount_due' => $total_due,
+    'unreturned_batteries_charge' => $battery_charge,
+    'tool_replacement_charge' => $replacement_charge,
+  ]);
 }
 
 /**
@@ -1525,11 +1535,14 @@ function lending_library_mail($key, &$message, $params) {
     case 'overdue':
     case 'overdue_30_day':
     case 'condition_charge':
+    case 'overdue_late_fee':
         $replacements = [
             '[tool_name]' => $params['tool_name'] ?? '',
             '[borrower_name]' => $params['borrower_name'] ?? '',
             '[amount_due]' => isset($params['amount_due']) ? number_format($params['amount_due'], 2) : '',
             '[payment_link]' => $params['payment_link'] ?? '',
+            '[tool_replacement_charge]' => isset($params['tool_replacement_charge']) ? number_format($params['tool_replacement_charge'], 2) : '',
+            '[unreturned_batteries_charge]' => isset($params['unreturned_batteries_charge']) ? number_format($params['unreturned_batteries_charge'], 2) : '',
         ];
 
         if ($key === 'due_soon') {


### PR DESCRIPTION
… and the module's settings page based on user feedback.

Key Changes:

- **Fatal Error Fix:** Corrected fatal errors on the test trigger form caused by previous refactoring.
- **Flexible Billing Logic:**
  - The cron job now applies a configurable daily late fee.
  - A configurable cap on late fees is now enforced.
  - The final non-return charge percentage and the number of days until it's applied are now configurable.
  - The non-return charge is now also applied to the value of any unreturned batteries.
- **Settings Page Overhaul:**
  - The settings page has been completely reorganized for a more logical user experience, grouping settings with their corresponding email templates.
  - All email templates now have descriptions explaining when they are triggered.
  - UI improvements like a '$' prefix for the daily fee have been added.
- **New Email Patterns:**
  - Added dynamic `[tool_replacement_charge]` and `[unreturned_batteries_charge]` patterns for use in emails.