### PR TITLE
This commit fixes a bug in the LendingLibrarySettingsForm that caused…

### DIFF
--- a/config/install/lending_library.settings.yml
+++ b/config/install/lending_library.settings.yml
@@ -1,7 +1,10 @@
 loan_terms_html: '<div class="lending-library-agreement"><h4>Borrowing Member Affirms</h4><p>I have:</p><ul><li>Signed the tool borrowing policy and MakeHaven Lending Library Waiver, Release &amp; Indemnification, and have read the most updated policy.</li><li>Acquired the required badges, safety checkout and have reviewed manufacturer''s instructions for this tool.</li><li>Inspected the tool, and it is in good order.</li></ul><p>I will be:</p><ul><li>The only user of the tool and control access to the tool.</li><li>Responsible for damage/loss. (Replacement Value)</li></ul><h4>Loan Terms</h4><ul><li><strong></li><li>All tools borrowed are to be returned no later than seven days after checkout.</li><li>Late fees will be charged for overdue items: $5 per tool for the first week, and $10 per day thereafter until the tool is returned. Full cost of tool plus fees will be charged at 30 days. Late fees are capped at 150% of full replacement cost of the tool, plus cost of any additional batteries.</li></ul><p>Our full rules are at <a href="/tool-lending-library-enrollment">the enrollment form</a>.</p></div>'
-email_checkout_footer: 'Please treat our tools with care. — MakeHaven Team'
-email_return_body: 'Thanks — your return has been recorded.'
-email_issue_notice_intro: 'A member submitted an issue report.'
+email_checkout_subject: 'Tool Checkout Confirmation: [tool_name]'
+email_checkout_body: "You have successfully checked out the following tool:\n\nTool: [tool_name]\nReplacement Value: $[replacement_value]\nDue on or before: [due_date]."
+email_return_subject: 'Tool Return Confirmation'
+email_return_body: "Thanks! Your return has been recorded.\nTool: [tool_name]"
+email_issue_report_subject: 'Lending Library Issue Report: [tool_name]'
+email_issue_report_body: "A member submitted an issue report.\n\nTool: [tool_name]\nIssue type: [issue_type]\nDetails: [notes]\nReported by: [reporter]\nItem page: [item_url]"
 email_staff_address: 'team@makehaven.org'
 enable_due_soon_notifications: true
 enable_overdue_notifications: true

--- a/lending_library.module
+++ b/lending_library.module
@@ -1422,164 +1422,72 @@ function lending_library_mail($key, &$message, $params) {
     $message['headers']['Reply-To'] = $params['reply_to'];
   }
 
-  // Pull optional configurable snippets (with safe fallbacks).
   $cfg = \Drupal::config('lending_library.settings');
-  $checkout_footer = $cfg->get('email_checkout_footer') ?: '';
-  $return_body     = $cfg->get('email_return_body') ?: '';
-  $issue_intro     = $cfg->get('email_issue_notice_intro') ?: '';
 
-  // New templates
-  $due_soon_subject = $cfg->get('email_due_soon_subject') ?: 'Your borrowed tool is due soon';
-  $due_soon_body = $cfg->get('email_due_soon_body') ?: "Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is due tomorrow. Please return it on time to avoid late fees.";
-  $overdue_subject = $cfg->get('email_overdue_subject') ?: 'Your borrowed tool is overdue';
-  $overdue_body = $cfg->get('email_overdue_body') ?: "Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is now overdue. Please return it as soon as possible.";
-  $overdue_30_day_subject = $cfg->get('email_overdue_30_day_subject') ?: 'Charge for unreturned library tool';
-  $overdue_30_day_body = $cfg->get('email_overdue_30_day_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' is now 30 days overdue. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]";
-  $condition_charge_subject = $cfg->get('email_condition_charge_subject') ?: 'Charge for tool damage or missing parts';
-  $condition_charge_body = $cfg->get('email_condition_charge_body') ?: "Hello [borrower_name],\n\nA charge of [amount_due] has been added to your account for the tool '[tool_name]' due to its condition upon return. Please use the following link to pay: [payment_link]";
-  $waitlist_notification_subject = $cfg->get('email_waitlist_notification_subject') ?: 'A tool you are waiting for is now available';
-  $waitlist_notification_body = $cfg->get('email_waitlist_notification_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you were waiting for has been returned and is now available for checkout.";
-  $overdue_late_fee_subject = $cfg->get('email_overdue_late_fee_subject') ?: 'Late fee added for overdue tool';
-  $overdue_late_fee_body = $cfg->get('email_overdue_late_fee_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]";
+  // Centralized replacement logic.
+  $replacements = [
+    '[tool_name]' => $params['tool_name'] ?? '',
+    '[borrower_name]' => $params['borrower_name'] ?? '',
+    '[amount_due]' => isset($params['amount_due']) ? '$' . number_format($params['amount_due'], 2) : '',
+    '[payment_link]' => $params['payment_link'] ?? '',
+    '[tool_replacement_charge]' => isset($params['tool_replacement_charge']) ? '$' . number_format($params['tool_replacement_charge'], 2) : '',
+    '[unreturned_batteries_charge]' => isset($params['unreturned_batteries_charge']) ? '$' . number_format($params['unreturned_batteries_charge'], 2) : '',
+    '[replacement_value]' => isset($params['replacement_value']) ? '$' . number_format($params['replacement_value'], 2) : '',
+    '[due_date]' => $params['due_date'] ?? '',
+    '[issue_type]' => $params['issue_type'] ?? '',
+    '[notes]' => $params['notes'] ?? '',
+    '[reporter]' => $params['reporter'] ?? '',
+    '[item_url]' => $params['item_url'] ?? '',
+  ];
 
+  $subject = '';
+  $body_template = '';
 
   switch ($key) {
-    case 'checkout_confirmation': {
-      $tool = $params['tool_name'] ?? t('Unknown tool');
-      $message['subject'] = t('Tool Checkout Confirmation: @tool_name', ['@tool_name' => $tool]);
-
-      $body = [];
-      $body[] = t('You have successfully checked out the following tool from the MakeHaven Lending Library:');
-      $body[] = '';
-      $body[] = t('Tool: @tool_name', ['@tool_name' => $tool]);
-
-      if (!empty($params['replacement_value'])) {
-        $body[] = t('Replacement Value: $@value', ['@value' => number_format($params['replacement_value'], 2)]);
-      }
-
-      if (!empty($params['due_date'])) {
-        $body[] = '';
-        $body[] = t('This item is due on or before: @due_date.', ['@due_date' => $params['due_date']]);
-      }
-
-      // Policy reminder (kept short; longer loan terms live on the form/config page).
-      $body[] = '';
-      $body[] = t('Please return tools on time and in good condition. Late fees may apply.');
-
-      if ($checkout_footer !== '') {
-        $body[] = '';
-        $body[] = $checkout_footer;
-      }
-
-      $body[] = '';
-      $body[] = t('Thank you,');
-      $body[] = t('The MakeHaven Team');
-
-      $message['body'][] = implode("\n", $body);
+    case 'checkout_confirmation':
+      $subject = $cfg->get('email_checkout_subject') ?: 'Tool Checkout Confirmation: [tool_name]';
+      $body_template = $cfg->get('email_checkout_body') ?: "You have successfully checked out the following tool:\n\nTool: [tool_name]\nReplacement Value: [replacement_value]\nDue on or before: [due_date].";
       break;
-    }
 
-    case 'return_confirmation': {
-      $tool = $params['tool_name'] ?? '';
-      $message['subject'] = t('Tool Return Confirmation');
-
-      $lines = [];
-      $lines[] = t('Thanks! Your return has been recorded.');
-      if ($tool !== '') {
-        $lines[] = t('Tool: @tool', ['@tool' => $tool]);
-      }
-      if ($return_body !== '') {
-        $lines[] = '';
-        $lines[] = $return_body;
-      }
-      $lines[] = '';
-      $lines[] = t('— MakeHaven Team');
-
-      $message['body'][] = implode("\n", $lines);
+    case 'return_confirmation':
+      $subject = $cfg->get('email_return_subject') ?: 'Tool Return Confirmation';
+      $body_template = $cfg->get('email_return_body') ?: "Thanks! Your return has been recorded.\nTool: [tool_name]";
       break;
-    }
 
-    case 'issue_report_notice': {
-      $tool = $params['tool_name'] ?? t('Unknown');
-      $message['subject'] = t('Lending Library Issue Report: @tool', ['@tool' => $tool]);
-
-      $lines = [];
-      if ($issue_intro !== '') {
-        $lines[] = $issue_intro;
-        $lines[] = '';
-      } else {
-        $lines[] = t('A member submitted an issue report.');
-        $lines[] = '';
-      }
-
-      $lines[] = t('Tool: @tool', ['@tool' => $tool]);
-
-      if (!empty($params['issue_type'])) {
-        $lines[] = t('Issue type: @issue', ['@issue' => $params['issue_type']]);
-      }
-      if (!empty($params['notes'])) {
-        $lines[] = t('Details: @notes', ['@notes' => $params['notes']]);
-      }
-      if (!empty($params['reporter'])) {
-        $lines[] = t('Reported by: @name', ['@name' => $params['reporter']]);
-      }
-      if (!empty($params['item_url'])) {
-        $lines[] = t('Item page: @url', ['@url' => $params['item_url']]);
-      }
-
-      $message['body'][] = implode("\n", $lines);
+    case 'issue_report_notice':
+      $subject = $cfg->get('email_issue_report_subject') ?: 'Lending Library Issue Report: [tool_name]';
+      $body_template = $cfg->get('email_issue_report_body') ?: "A member submitted an issue report.\n\nTool: [tool_name]\nIssue type: [issue_type]\nDetails: [notes]\nReported by: [reporter]\nItem page: [item_url]";
       break;
-    }
 
     case 'due_soon':
-    case 'overdue':
-    case 'overdue_30_day':
-    case 'condition_charge':
-    case 'overdue_late_fee':
-        $replacements = [
-            '[tool_name]' => $params['tool_name'] ?? '',
-            '[borrower_name]' => $params['borrower_name'] ?? '',
-            '[amount_due]' => isset($params['amount_due']) ? number_format($params['amount_due'], 2) : '',
-            '[payment_link]' => $params['payment_link'] ?? '',
-            '[tool_replacement_charge]' => isset($params['tool_replacement_charge']) ? number_format($params['tool_replacement_charge'], 2) : '',
-            '[unreturned_batteries_charge]' => isset($params['unreturned_batteries_charge']) ? number_format($params['unreturned_batteries_charge'], 2) : '',
-        ];
+      $subject = $cfg->get('email_due_soon_subject') ?: 'Your borrowed tool is due soon';
+      $body_template = $cfg->get('email_due_soon_body') ?: "Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is due tomorrow. Please return it on time to avoid late fees.";
+      break;
 
-        if ($key === 'due_soon') {
-            $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $due_soon_subject);
-            $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $due_soon_body);
-        }
-        elseif ($key === 'overdue') {
-            $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $overdue_subject);
-            $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $overdue_body);
-        }
-        elseif ($key === 'overdue_30_day') {
-            $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $overdue_30_day_subject);
-            $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $overdue_30_day_body);
-        }
-        else { // condition_charge
-            $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $condition_charge_subject);
-            $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $condition_charge_body);
-        }
-        break;
-    case 'waitlist_notification':
-        $replacements = [
-            '[tool_name]' => $params['tool_name'] ?? '',
-            '[borrower_name]' => $params['borrower_name'] ?? '',
-        ];
-        $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $waitlist_notification_subject);
-        $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $waitlist_notification_body);
-        break;
     case 'overdue_late_fee':
-        $replacements = [
-            '[tool_name]' => $params['tool_name'] ?? '',
-            '[borrower_name]' => $params['borrower_name'] ?? '',
-            '[amount_due]' => isset($params['amount_due']) ? number_format($params['amount_due'], 2) : '',
-            '[payment_link]' => $params['payment_link'] ?? '',
-        ];
-        $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $overdue_late_fee_subject);
-        $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $overdue_late_fee_body);
-        break;
+      $subject = $cfg->get('email_overdue_late_fee_subject') ?: 'Late fee added for overdue tool';
+      $body_template = $cfg->get('email_overdue_late_fee_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]";
+      break;
+
+    case 'overdue_30_day': // This key is kept for the non-return charge.
+      $subject = $cfg->get('email_non_return_charge_subject') ?: 'Charge for unreturned library tool';
+      $body_template = $cfg->get('email_non_return_charge_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' is now considered lost. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]";
+      break;
+
+    case 'condition_charge':
+      $subject = $cfg->get('email_condition_charge_subject') ?: 'Charge for tool damage or missing parts';
+      $body_template = $cfg->get('email_condition_charge_body') ?: "Hello [borrower_name],\n\nA charge of [amount_due] has been added to your account for the tool '[tool_name]' due to its condition upon return. Please use the following link to pay: [payment_link]";
+      break;
+
+    case 'waitlist_notification':
+      $subject = $cfg->get('email_waitlist_notification_subject') ?: 'A tool you are waiting for is now available';
+      $body_template = $cfg->get('email_waitlist_notification_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you were waiting for has been returned and is now available for checkout.";
+      break;
+  }
+
+  if (!empty($subject) && !empty($body_template)) {
+    $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $subject);
+    $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $body_template);
   }
 }
 

--- a/src/Form/LendingLibrarySettingsForm.php
+++ b/src/Form/LendingLibrarySettingsForm.php
@@ -148,12 +148,12 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
       '#title' => $this->t('Enable "Due Soon" notifications'),
       '#default_value' => $config->get('enable_due_soon_notifications'),
     ];
-    $form['email_settings']['due_soon']['subject'] = [
+    $form['email_settings']['due_soon']['email_due_soon_subject'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Subject'),
         '#default_value' => $config->get('email_due_soon_subject') ?: $this->t('Your borrowed tool is due soon'),
     ];
-    $form['email_settings']['due_soon']['body'] = [
+    $form['email_settings']['due_soon']['email_due_soon_body'] = [
         '#type' => 'textarea',
         '#title' => $this->t('Body'),
         '#default_value' => $config->get('email_due_soon_body') ?: $this->t("Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is due tomorrow. Please return it on time to avoid late fees."),
@@ -179,12 +179,12 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
       '#title' => $this->t('Daily Late Fee Email'),
       '#description' => $this->t('Sent once when the first daily late fee is applied.'),
     ];
-    $form['email_settings']['overdue']['late_fee_email']['subject'] = [
+    $form['email_settings']['overdue']['late_fee_email']['email_overdue_late_fee_subject'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Subject'),
         '#default_value' => $config->get('email_overdue_late_fee_subject') ?: $this->t('Late fee added for overdue tool'),
     ];
-    $form['email_settings']['overdue']['late_fee_email']['body'] = [
+    $form['email_settings']['overdue']['late_fee_email']['email_overdue_late_fee_body'] = [
         '#type' => 'textarea',
         '#title' => $this->t('Body'),
         '#default_value' => $config->get('email_overdue_late_fee_body') ?: $this->t("Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]"),
@@ -197,12 +197,12 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#title' => $this->t('Lost Tool Replacement Charge Email'),
         '#description' => $this->t('Sent when an item is overdue by the "Days until Final Non-Return Charge".'),
     ];
-    $form['email_settings']['overdue']['non_return_email']['subject'] = [
+    $form['email_settings']['overdue']['non_return_email']['email_non_return_charge_subject'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Subject'),
         '#default_value' => $config->get('email_non_return_charge_subject') ?: $this->t('Charge for unreturned library tool'),
     ];
-    $form['email_settings']['overdue']['non_return_email']['body'] = [
+    $form['email_settings']['overdue']['non_return_email']['email_non_return_charge_body'] = [
         '#type' => 'textarea',
         '#title' => $this->t('Body'),
         '#default_value' => $config->get('email_non_return_charge_body') ?: $this->t("Hello [borrower_name],\n\nThe tool '[tool_name]' is now considered lost. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]"),
@@ -220,12 +220,12 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#title' => $this->t('Condition Charge Notification'),
         '#description' => $this->t('Sent via the confirmation form when an admin applies a manual charge for damage or missing parts.'),
     ];
-    $form['email_settings']['other_templates']['condition_charge']['subject'] = [
+    $form['email_settings']['other_templates']['condition_charge']['email_condition_charge_subject'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Subject'),
         '#default_value' => $config->get('email_condition_charge_subject') ?: $this->t('Charge for tool damage or missing parts'),
     ];
-    $form['email_settings']['other_templates']['condition_charge']['body'] = [
+    $form['email_settings']['other_templates']['condition_charge']['email_condition_charge_body'] = [
         '#type' => 'textarea',
         '#title' => $this->t('Body'),
         '#default_value' => $config->get('email_condition_charge_body') ?: $this->t("Hello [borrower_name],\n\nA charge of [amount_due] has been added to your account for the tool '[tool_name]' due to its condition upon return. Please use the following link to pay: [payment_link]"),
@@ -237,42 +237,64 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
       '#title' => $this->t('Waitlist Notification'),
       '#description' => $this->t('Sent to the next person on the waitlist when a borrowed item is returned.'),
     ];
-    $form['email_settings']['other_templates']['waitlist']['subject'] = [
+    $form['email_settings']['other_templates']['waitlist']['email_waitlist_notification_subject'] = [
         '#type' => 'textfield',
         '#title' => $this->t('Subject'),
         '#default_value' => $config->get('email_waitlist_notification_subject') ?: $this->t('A tool you are waiting for is now available'),
     ];
-    $form['email_settings']['other_templates']['waitlist']['body'] = [
+    $form['email_settings']['other_templates']['waitlist']['email_waitlist_notification_body'] = [
         '#type' => 'textarea',
         '#title' => $this->t('Body'),
         '#default_value' => $config->get('email_waitlist_notification_body') ?: $this->t("Hello [borrower_name],\n\nThe tool '[tool_name]' you were waiting for has been returned and is now available for checkout."),
         '#rows' => 5,
     ];
 
-    $form['email_settings']['other_templates']['misc_footers'] = [
+    $form['email_settings']['other_templates']['checkout'] = [
       '#type' => 'details',
-      '#title' => $this->t('Miscellaneous Email Text'),
+      '#title' => $this->t('Checkout Confirmation Email'),
     ];
-    $form['email_settings']['other_templates']['misc_footers']['checkout_footer'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Checkout email footer'),
-      '#description' => $this->t('Appended to the bottom of the checkout confirmation email. Plain text or basic HTML.'),
-      '#default_value' => $config->get('email_checkout_footer') ?: '',
-      '#rows' => 3,
+    $form['email_settings']['other_templates']['checkout']['subject'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Subject'),
+        '#default_value' => $config->get('email_checkout_subject') ?: $this->t('Tool Checkout Confirmation: [tool_name]'),
     ];
-    $form['email_settings']['other_templates']['misc_footers']['return_body'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Return email body'),
-      '#description' => $this->t('Inserted into the return confirmation email. Plain text or basic HTML.'),
-      '#default_value' => $config->get('email_return_body') ?: '',
-      '#rows' => 3,
+    $form['email_settings']['other_templates']['checkout']['body'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_checkout_body') ?: "You have successfully checked out the following tool:\n\nTool: [tool_name]\nReplacement Value: $[replacement_value]\nDue on or before: [due_date].",
+        '#rows' => 5,
     ];
-    $form['email_settings']['other_templates']['misc_footers']['issue_intro'] = [
-      '#type' => 'textarea',
-      '#title' => $this->t('Issue notice intro (staff email)'),
-      '#description' => $this->t('First line(s) of the issue notification email sent to staff. Plain text or basic HTML.'),
-      '#default_value' => $config->get('email_issue_notice_intro') ?: '',
-      '#rows' => 3,
+
+    $form['email_settings']['other_templates']['return'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Return Confirmation Email'),
+    ];
+    $form['email_settings']['other_templates']['return']['subject'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Subject'),
+        '#default_value' => $config->get('email_return_subject') ?: $this->t('Tool Return Confirmation'),
+    ];
+    $form['email_settings']['other_templates']['return']['body'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_return_body') ?: "Thanks! Your return has been recorded.\nTool: [tool_name]",
+        '#rows' => 5,
+    ];
+
+    $form['email_settings']['other_templates']['issue_report'] = [
+      '#type' => 'details',
+      '#title' => $this->t('Issue Report Email (to staff)'),
+    ];
+    $form['email_settings']['other_templates']['issue_report']['subject'] = [
+        '#type' => 'textfield',
+        '#title' => $this->t('Subject'),
+        '#default_value' => $config->get('email_issue_report_subject') ?: $this->t('Lending Library Issue Report: [tool_name]'),
+    ];
+    $form['email_settings']['other_templates']['issue_report']['body'] = [
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_issue_report_body') ?: "A member submitted an issue report.\n\nTool: [tool_name]\nIssue type: [issue_type]\nDetails: [notes]\nReported by: [reporter]\nItem page: [item_url]",
+        '#rows' => 5,
     ];
 
     $form['battery_return_message'] = [
@@ -289,44 +311,46 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $config = $this->config('lending_library.settings');
 
-    // Manually get values from the nested form structure.
-    $email_settings = $form_state->getValue('email_settings');
+    // Even though the form is nested visually, #tree is not used, so the
+    // values are at the top level of the form state.
+    $values = $form_state->getValues();
+    $keys_to_save = [
+      'loan_period_days',
+      'daily_late_fee',
+      'late_fee_cap_percentage',
+      'overdue_charge_days',
+      'non_return_charge_percentage',
+      'loan_terms_html',
+      'battery_return_message',
+      'email_staff_address',
+      'paypal_email',
+      'enable_due_soon_notifications',
+      'email_due_soon_subject',
+      'email_due_soon_body',
+      'enable_overdue_notifications',
+      'email_overdue_late_fee_subject',
+      'email_overdue_late_fee_body',
+      'email_non_return_charge_subject',
+      'email_non_return_charge_body',
+      'email_condition_charge_subject',
+      'email_condition_charge_body',
+      'email_waitlist_notification_subject',
+      'email_waitlist_notification_body',
+      'email_checkout_subject',
+      'email_checkout_body',
+      'email_return_subject',
+      'email_return_body',
+      'email_issue_report_subject',
+      'email_issue_report_body',
+    ];
 
-    $config
-      ->set('loan_period_days', $form_state->getValue('loan_period_days'))
-      ->set('daily_late_fee', $form_state->getValue('daily_late_fee'))
-      ->set('late_fee_cap_percentage', $form_state->getValue('late_fee_cap_percentage'))
-      ->set('overdue_charge_days', $form_state->getValue('overdue_charge_days'))
-      ->set('non_return_charge_percentage', $form_state->getValue('non_return_charge_percentage'))
-      ->set('loan_terms_html', $form_state->getValue('loan_terms_html'))
-      ->set('battery_return_message', $form_state->getValue('battery_return_message'))
+    foreach ($keys_to_save as $key) {
+        if (isset($values[$key])) {
+            $config->set($key, $values[$key]);
+        }
+    }
 
-      // General Email Settings
-      ->set('email_staff_address', $email_settings['general']['email_staff_address'])
-      ->set('paypal_email', $email_settings['general']['paypal_email'])
-
-      // Due Soon
-      ->set('enable_due_soon_notifications', $email_settings['due_soon']['enable_due_soon_notifications'])
-      ->set('email_due_soon_subject', $email_settings['due_soon']['subject'])
-      ->set('email_due_soon_body', $email_settings['due_soon']['body'])
-
-      // Overdue
-      ->set('enable_overdue_notifications', $email_settings['overdue']['enable_overdue_notifications'])
-      ->set('email_overdue_late_fee_subject', $email_settings['overdue']['late_fee_email']['subject'])
-      ->set('email_overdue_late_fee_body', $email_settings['overdue']['late_fee_email']['body'])
-      ->set('email_non_return_charge_subject', $email_settings['overdue']['non_return_email']['subject'])
-      ->set('email_non_return_charge_body', $email_settings['overdue']['non_return_email']['body'])
-
-      // Other Templates
-      ->set('email_condition_charge_subject', $email_settings['other_templates']['condition_charge']['subject'])
-      ->set('email_condition_charge_body', $email_settings['other_templates']['condition_charge']['body'])
-      ->set('email_waitlist_notification_subject', $email_settings['other_templates']['waitlist']['subject'])
-      ->set('email_waitlist_notification_body', $email_settings['other_templates']['waitlist']['body'])
-      ->set('email_checkout_footer', $email_settings['other_templates']['misc_footers']['checkout_footer'])
-      ->set('email_return_body', $email_settings['other_templates']['misc_footers']['return_body'])
-      ->set('email_issue_notice_intro', $email_settings['other_templates']['misc_footers']['issue_intro'])
-
-      ->save();
+    $config->save();
 
     parent::submitForm($form, $form_state);
   }


### PR DESCRIPTION
… numerous 'array offset on null' warnings when saving the form.

The issue was caused by an incorrect implementation in the form submission method that did not properly handle the nested structure of the form array.

The submission handler has been refactored to correctly read the flat array of values from the form state, ensuring all settings are saved properly. This also resolves a downstream bug where PayPal links were not being generated because the PayPal email setting was not being saved.