### PR TITLE
Enhance lending library with new checkout restrictions and permissions.

### DIFF
--- a/lending_library.module
+++ b/lending_library.module
@@ -530,6 +530,78 @@ function _lending_library_transaction_form_validate(&$form, FormStateInterface $
     if (!$form_state->getValue('lending_library_agreement_acknowledge')) {
       $form_state->setErrorByName('lending_library_agreement_acknowledge', t('You must acknowledge and agree to the terms before borrowing this tool.'));
     }
+
+    $config = \Drupal::config('lending_library.settings');
+    $current_user_id = \Drupal::currentUser()->id();
+    $library_item_node = \Drupal::entityTypeManager()->getStorage('node')->load($transaction_entity->get(LENDING_LIBRARY_TRANSACTION_ITEM_REF_FIELD)->target_id);
+
+    // Check for outstanding debt.
+    if ($config->get('prevent_checkout_with_debt')) {
+      $query = \Drupal::entityQuery('library_transaction')
+        ->accessCheck(FALSE)
+        ->condition(LENDING_LIBRARY_TRANSACTION_BORROWER_FIELD, $current_user_id)
+        ->condition('field_library_charges_status', 'paid', '<>')
+        ->condition('field_library_amount_due', 0, '>');
+      $debt_transactions = $query->execute();
+      if (!empty($debt_transactions)) {
+        $form_state->setErrorByName('lending_library_agreement_acknowledge', t('You have outstanding debts and cannot borrow new items until they are paid.'));
+      }
+    }
+
+    // Check for overdue items.
+    if ($config->get('prevent_checkout_with_overdue')) {
+      $now = new DrupalDateTime('now');
+      $query = \Drupal::entityQuery('library_transaction')
+        ->accessCheck(FALSE)
+        ->condition(LENDING_LIBRARY_TRANSACTION_BORROWER_FIELD, $current_user_id)
+        ->condition(LENDING_LIBRARY_TRANSACTION_DUE_DATE_FIELD, $now->format('Y-m-d'), '<')
+        ->condition(LENDING_LIBRARY_TRANSACTION_RETURN_DATE_FIELD, NULL, 'IS NULL');
+      $overdue_transactions = $query->execute();
+      if (!empty($overdue_transactions)) {
+        $form_state->setErrorByName('lending_library_agreement_acknowledge', t('You have overdue items and cannot borrow new items until they are returned.'));
+      }
+    }
+
+    // Check for max tool count.
+    $max_tool_count = $config->get('max_tool_count');
+    if (!empty($max_tool_count) && $max_tool_count > 0) {
+      $query = \Drupal::entityQuery('node')
+        ->accessCheck(FALSE)
+        ->condition('type', LENDING_LIBRARY_ITEM_NODE_TYPE)
+        ->condition(LENDING_LIBRARY_ITEM_BORROWER_FIELD, $current_user_id);
+      $borrowed_count = $query->count()->execute();
+      if ($borrowed_count >= $max_tool_count) {
+        $form_state->setErrorByName('lending_library_agreement_acknowledge', t('You have reached the maximum number of borrowed items (@count).', ['@count' => $max_tool_count]));
+      }
+    }
+
+    // Check for max tool value.
+    $max_tool_value = $config->get('max_tool_value');
+    if (!empty($max_tool_value) && $max_tool_value > 0) {
+      $query = \Drupal::entityQuery('node')
+        ->accessCheck(FALSE)
+        ->condition('type', LENDING_LIBRARY_ITEM_NODE_TYPE)
+        ->condition(LENDING_LIBRARY_ITEM_BORROWER_FIELD, $current_user_id);
+      $borrowed_ids = $query->execute();
+      $borrowed_value = 0;
+      if (!empty($borrowed_ids)) {
+        $borrowed_items = \Drupal::entityTypeManager()->getStorage('node')->loadMultiple($borrowed_ids);
+        foreach ($borrowed_items as $borrowed_item) {
+          if ($borrowed_item->hasField(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD) && !$borrowed_item->get(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD)->isEmpty()) {
+            $borrowed_value += $borrowed_item->get(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD)->value;
+          }
+        }
+      }
+
+      $current_item_value = 0;
+      if ($library_item_node->hasField(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD) && !$library_item_node->get(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD)->isEmpty()) {
+        $current_item_value = $library_item_node->get(LENDING_LIBRARY_ITEM_REPLACEMENT_VALUE_FIELD)->value;
+      }
+
+      if (($borrowed_value + $current_item_value) > $max_tool_value) {
+        $form_state->setErrorByName('lending_library_agreement_acknowledge', t('This item would exceed your maximum allowed total borrowing value ($@value).', ['@value' => $max_tool_value]));
+      }
+    }
   }
 
   if ($action === LENDING_LIBRARY_ACTION_RETURN) {

--- a/lending_library.permissions.yml
+++ b/lending_library.permissions.yml
@@ -20,6 +20,10 @@ administer lending library configuration:
   title: 'Administer Lending Library configuration'
   description: 'Allows users to access the Lending Library configuration page.'
 
+administer lending library payment configuration:
+  title: 'Administer Lending Library payment configuration'
+  description: 'Allows users to change the PayPal account on the Lending Library configuration page.'
+
 'get in line for library items':
   title: 'Get in line for library items'
   description: 'Allows users to add themselves to the waitlist for a library item.'

--- a/src/Form/LendingLibrarySettingsForm.php
+++ b/src/Form/LendingLibrarySettingsForm.php
@@ -33,6 +33,38 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
       '#min' => 1,
     ];
 
+    $form['loan_settings']['prevent_checkout_with_debt'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Prevent checkout with outstanding debt'),
+      '#description' => $this->t('If checked, users will not be able to check out new items if they have any unpaid fees.'),
+      '#default_value' => $config->get('prevent_checkout_with_debt'),
+    ];
+
+    $form['loan_settings']['prevent_checkout_with_overdue'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Prevent checkout with overdue items'),
+      '#description' => $this->t('If checked, users will not be able to check out new items if they have any items that are currently overdue.'),
+      '#default_value' => $config->get('prevent_checkout_with_overdue'),
+    ];
+
+    $form['loan_settings']['max_tool_count'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum tool count'),
+      '#description' => $this->t('The maximum number of tools a user can have checked out at one time. Set to 0 for no limit.'),
+      '#default_value' => $config->get('max_tool_count') ?: 0,
+      '#min' => 0,
+    ];
+
+    $form['loan_settings']['max_tool_value'] = [
+      '#type' => 'number',
+      '#title' => $this->t('Maximum tool value'),
+      '#description' => $this->t('The maximum total value of tools a user can have checked out at one time. Set to 0 for no limit.'),
+      '#default_value' => $config->get('max_tool_value') ?: 0,
+      '#min' => 0,
+      '#step' => '0.01',
+      '#field_prefix' => '$',
+    ];
+
     $form['fee_settings'] = [
       '#type' => 'details',
       '#title' => $this->t('Fee and Fine Settings'),
@@ -134,6 +166,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '@ipn_url' => Url::fromRoute('lending_library.paypal_ipn_listener', [], ['absolute' => TRUE])->toString(),
       ]),
       '#default_value' => $config->get('paypal_email') ?: '',
+      '#access' => \Drupal::currentUser()->hasPermission('administer lending library payment configuration'),
     ];
 
     // Due Soon Notifications
@@ -316,6 +349,10 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
     $values = $form_state->getValues();
     $keys_to_save = [
       'loan_period_days',
+      'prevent_checkout_with_debt',
+      'prevent_checkout_with_overdue',
+      'max_tool_count',
+      'max_tool_value',
       'daily_late_fee',
       'late_fee_cap_percentage',
       'overdue_charge_days',


### PR DESCRIPTION
This commit introduces several new features to the lending library module:

-   **Checkout Restrictions:**
    -   Prevents users with outstanding debt from checking out new items.
    -   Prevents users with overdue items from checking out new items.
    -   Adds configuration options to limit the total number of tools and the total value of tools a user can borrow at one time.

-   **Permissions:**
    -   Creates a new permission to control who can change the PayPal account information.