### PR TITLE
Fix HTML emails not rendering

### DIFF
--- a/lending_library.module
+++ b/lending_library.module
@@ -1490,7 +1490,7 @@ function lending_library_mail($key, &$message, $params) {
     $message['headers']['Reply-To'] = $params['reply_to'];
   }
 
-  $message['headers']['Content-Type'] = 'text/html; charset=UTF-8; format=flowed; delsp=yes';
+  $message['headers']['Content-Type'] = 'text/html; charset=UTF-8';
 
   $cfg = \Drupal::config('lending_library.settings');
 


### PR DESCRIPTION
This commit fixes an issue where emails were still being sent as plain text instead of HTML.

The `Content-Type` header was simplified to `text/html; charset=UTF-8` to ensure it is correctly interpreted by email clients.