### PR TITLE
Fix HTML emails not rendering

### DIFF
--- a/lending_library.module
+++ b/lending_library.module
@@ -1490,7 +1490,6 @@ function lending_library_mail($key, &$message, $params) {
     $message['headers']['Reply-To'] = $params['reply_to'];
   }
 
-  $message['headers']['Content-Type'] = 'text/html; charset=UTF-8';
 
   $cfg = \Drupal::config('lending_library.settings');
 
@@ -1578,7 +1577,8 @@ function lending_library_mail($key, &$message, $params) {
 
   if (!empty($subject) && !empty($body_template)) {
     $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $subject);
-    $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $body_template);
+    $html = str_replace(array_keys($replacements), array_values($replacements), $body_template);
+    $message['body'] = [$html];
   }
 }
 


### PR DESCRIPTION
This commit fixes an issue where emails were still being sent as plain text instead of HTML.

Following the advice from the user, this commit:
- Removes the hard-coded `Content-Type` header.
- Sets the message body to an array containing the HTML string, allowing the mailer to handle the formatting.