### PR TITLE
Revert HTML email changes and restore text-only emails

### DIFF
--- a/lending_library.module
+++ b/lending_library.module
@@ -469,8 +469,7 @@ if (!empty($form[LENDING_LIBRARY_TRANSACTION_BORROW_BATTERIES_FIELD]['#access'])
     }
 
 // --- AGREEMENT: config-only (withdraw action) --- //
-$terms_config = \Drupal::config('lending_library.settings')->get('loan_terms_html');
-$terms_html = is_array($terms_config) ? $terms_config['value'] : $terms_config;
+$terms_html = \Drupal::config('lending_library.settings')->get('loan_terms_html');
 if (empty($terms_html)) {
   // Safe fallback if config is empty or not installed yet.
   $terms_html = '<h4>Loan Terms</h4><ul>'
@@ -1490,7 +1489,6 @@ function lending_library_mail($key, &$message, $params) {
     $message['headers']['Reply-To'] = $params['reply_to'];
   }
 
-
   $cfg = \Drupal::config('lending_library.settings');
 
   // Generate payment link if applicable.
@@ -1528,80 +1526,48 @@ function lending_library_mail($key, &$message, $params) {
   switch ($key) {
     case 'checkout_confirmation':
       $subject = $cfg->get('email_checkout_subject') ?: 'Tool Checkout Confirmation: [tool_name]';
-      $body_cfg = $cfg->get('email_checkout_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "You have successfully checked out the following tool:\n\nTool: [tool_name]\nReplacement Value: [replacement_value]\nDue on or before: [due_date].";
-      }
+      $body_template = $cfg->get('email_checkout_body') ?: "You have successfully checked out the following tool:\n\nTool: [tool_name]\nReplacement Value: [replacement_value]\nDue on or before: [due_date].";
       break;
 
     case 'return_confirmation':
       $subject = $cfg->get('email_return_subject') ?: 'Tool Return Confirmation';
-      $body_cfg = $cfg->get('email_return_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Thanks! Your return has been recorded.\nTool: [tool_name]";
-      }
+      $body_template = $cfg->get('email_return_body') ?: "Thanks! Your return has been recorded.\nTool: [tool_name]";
       break;
 
     case 'issue_report_notice':
       $subject = $cfg->get('email_issue_report_subject') ?: 'Lending Library Issue Report: [tool_name]';
-      $body_cfg = $cfg->get('email_issue_report_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "A member submitted an issue report.\n\nTool: [tool_name]\nIssue type: [issue_type]\nDetails: [notes]\nReported by: [reporter]\nItem page: [item_url]";
-      }
+      $body_template = $cfg->get('email_issue_report_body') ?: "A member submitted an issue report.\n\nTool: [tool_name]\nIssue type: [issue_type]\nDetails: [notes]\nReported by: [reporter]\nItem page: [item_url]";
       break;
 
     case 'due_soon':
       $subject = $cfg->get('email_due_soon_subject') ?: 'Your borrowed tool is due soon';
-      $body_cfg = $cfg->get('email_due_soon_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is due tomorrow. Please return it on time to avoid late fees.";
-      }
+      $body_template = $cfg->get('email_due_soon_body') ?: "Hello [borrower_name],\n\nThis is a reminder that the tool '[tool_name]' you borrowed is due tomorrow. Please return it on time to avoid late fees.";
       break;
 
     case 'overdue_late_fee':
       $subject = $cfg->get('email_overdue_late_fee_subject') ?: 'Late fee added for overdue tool';
-      $body_cfg = $cfg->get('email_overdue_late_fee_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]";
-      }
+      $body_template = $cfg->get('email_overdue_late_fee_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you borrowed is overdue. A late fee of [amount_due] has been applied to your account. Please return the tool as soon as possible to avoid further fees. You can pay the current balance here: [payment_link]";
       break;
 
     case 'overdue_30_day': // This key is kept for the non-return charge.
       $subject = $cfg->get('email_non_return_charge_subject') ?: 'Charge for unreturned library tool';
-      $body_cfg = $cfg->get('email_non_return_charge_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Hello [borrower_name],\n\nThe tool '[tool_name]' is now considered lost. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]";
-      }
+      $body_template = $cfg->get('email_non_return_charge_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' is now considered lost. You are being charged [amount_due] for its replacement. Please use the following link to pay: [payment_link]";
       break;
 
     case 'condition_charge':
       $subject = $cfg->get('email_condition_charge_subject') ?: 'Charge for tool damage or missing parts';
-      $body_cfg = $cfg->get('email_condition_charge_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Hello [borrower_name],\n\nA charge of [amount_due] has been added to your account for the tool '[tool_name]' due to its condition upon return. Please use the following link to pay: [payment_link]";
-      }
+      $body_template = $cfg->get('email_condition_charge_body') ?: "Hello [borrower_name],\n\nA charge of [amount_due] has been added to your account for the tool '[tool_name]' due to its condition upon return. Please use the following link to pay: [payment_link]";
       break;
 
     case 'waitlist_notification':
       $subject = $cfg->get('email_waitlist_notification_subject') ?: 'A tool you are waiting for is now available';
-      $body_cfg = $cfg->get('email_waitlist_notification_body');
-      $body_template = is_array($body_cfg) ? ($body_cfg['value'] ?? '') : ($body_cfg ?? '');
-      if (empty($body_template)) {
-        $body_template = "Hello [borrower_name],\n\nThe tool '[tool_name]' you were waiting for has been returned and is now available for checkout.";
-      }
+      $body_template = $cfg->get('email_waitlist_notification_body') ?: "Hello [borrower_name],\n\nThe tool '[tool_name]' you were waiting for has been returned and is now available for checkout.";
       break;
   }
 
   if (!empty($subject) && !empty($body_template)) {
     $message['subject'] = str_replace(array_keys($replacements), array_values($replacements), $subject);
-    $message['body'] = str_replace(array_keys($replacements), array_values($replacements), $body_template);
+    $message['body'][] = str_replace(array_keys($replacements), array_values($replacements), $body_template);
   }
 }
 

--- a/src/Form/LendingLibrarySettingsForm.php
+++ b/src/Form/LendingLibrarySettingsForm.php
@@ -114,11 +114,11 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
     ];
 
     $form['loan_settings']['loan_terms_html'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
+      '#type' => 'textarea',
       '#title' => $this->t('Loan terms (HTML shown on checkout form)'),
       '#description' => $this->t('This HTML replaces the agreement block on the Withdraw form. Basic HTML allowed. See available replacement patterns below.'),
-      '#default_value' => $config->get('loan_terms_html')['value'] ?: '',
+      '#default_value' => $config->get('loan_terms_html') ?: '',
+      '#rows' => 10,
     ];
 
     $form['replacement_patterns'] = [
@@ -187,10 +187,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_due_soon_subject') ?: $this->t('Your borrowed tool is due soon'),
     ];
     $form['email_settings']['due_soon']['email_due_soon_body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_due_soon_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_due_soon_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #0056a0;">Reminder: Your Tool is Due Soon</h2>
         <p>Hi [borrower_name],</p>
@@ -205,6 +204,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     // Overdue Notifications
@@ -232,10 +232,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_overdue_late_fee_subject') ?: $this->t('Late fee added for overdue tool'),
     ];
     $form['email_settings']['overdue']['late_fee_email']['email_overdue_late_fee_body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_overdue_late_fee_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_overdue_late_fee_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #d9534f;">Notice: Overdue Item</h2>
         <p>Hi [borrower_name],</p>
@@ -244,6 +243,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     // Non-Return Charge Email
@@ -258,10 +258,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_non_return_charge_subject') ?: $this->t('Charge for unreturned library tool'),
     ];
     $form['email_settings']['overdue']['non_return_email']['email_non_return_charge_body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_non_return_charge_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_non_return_charge_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #d9534f;">Notice: Lost Item Charge</h2>
         <p>Hi [borrower_name],</p>
@@ -291,6 +290,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     // Other Email Templates
@@ -310,10 +310,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_condition_charge_subject') ?: $this->t('Charge for tool damage or missing parts'),
     ];
     $form['email_settings']['other_templates']['condition_charge']['email_condition_charge_body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_condition_charge_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_condition_charge_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #d9534f;">Notice: Damage/Missing Parts Charge</h2>
         <p>Hi [borrower_name],</p>
@@ -330,6 +329,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     $form['email_settings']['other_templates']['waitlist'] = [
@@ -343,10 +343,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_waitlist_notification_subject') ?: $this->t('A tool you are waiting for is now available'),
     ];
     $form['email_settings']['other_templates']['waitlist']['email_waitlist_notification_body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_waitlist_notification_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_waitlist_notification_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #5cb85c;">Great News! A Tool is Available!</h2>
         <p>Hi [borrower_name],</p>
@@ -355,6 +354,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     $form['email_settings']['other_templates']['checkout'] = [
@@ -367,10 +367,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_checkout_subject') ?: $this->t('Tool Checkout Confirmation: [tool_name]'),
     ];
     $form['email_settings']['other_templates']['checkout']['body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_checkout_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_checkout_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #0056a0;">Checkout Confirmation</h2>
         <p>Hi [borrower_name],</p>
@@ -392,6 +391,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     $form['email_settings']['other_templates']['return'] = [
@@ -404,10 +404,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_return_subject') ?: $this->t('Tool Return Confirmation'),
     ];
     $form['email_settings']['other_templates']['return']['body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_return_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_return_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #5cb85c;">Return Confirmed</h2>
         <p>Hi [borrower_name],</p>
@@ -416,6 +415,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         <p>Thanks,<br>The MakeHaven Team</p>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     $form['email_settings']['other_templates']['issue_report'] = [
@@ -428,10 +428,9 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         '#default_value' => $config->get('email_issue_report_subject') ?: $this->t('Lending Library Issue Report: [tool_name]'),
     ];
     $form['email_settings']['other_templates']['issue_report']['body'] = [
-      '#type' => 'text_format',
-      '#format' => 'full_html',
-      '#title' => $this->t('Body'),
-      '#default_value' => $config->get('email_issue_report_body')['value'] ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
+        '#type' => 'textarea',
+        '#title' => $this->t('Body'),
+        '#default_value' => $config->get('email_issue_report_body') ?: '<div style="font-family: sans-serif; padding: 20px; background-color: #f4f4f4; color: #333;">
     <div style="max-width: 600px; margin: auto; background: white; padding: 20px; border-radius: 5px;">
         <h2 style="color: #d9534f;">New Issue Report</h2>
         <p>A member has submitted an issue report for a library item.</p>
@@ -459,6 +458,7 @@ class LendingLibrarySettingsForm extends ConfigFormBase {
         </table>
     </div>
 </div>',
+        '#rows' => 15,
     ];
 
     $form['battery_return_message'] = [


### PR DESCRIPTION
This commit reverts the changes made in the attempt to implement HTML emails. The site is restored to a working state with text-only emails.

The key changes are:
- The `mailsystem` and `mimemail` modules have been uninstalled and removed from the project.
- The `lending_library.module` file has been reverted to its original state.
- The email body fields in `src/Form/LendingLibrarySettingsForm.php` have been reverted to `textarea` fields.

The new HTML email templates have been kept as the default values for the email body fields. They will be displayed as plain text in the emails, but they can be used as a starting point for a future attempt to implement HTML emails.